### PR TITLE
Fixes URI.unescape is obsolete

### DIFF
--- a/lib/dragonfly/utils.rb
+++ b/lib/dragonfly/utils.rb
@@ -38,7 +38,7 @@ module Dragonfly
     end
 
     def uri_unescape(string)
-      URI.unescape(string)
+      URI::DEFAULT_PARSER.unescape(string)
     end
 
   end


### PR DESCRIPTION
Fixes issue with `URI.unescape` being obsolete (ruby 2.7.1):
```
dragonfly-1.2.0/lib/dragonfly/utils.rb:41: warning: URI.unescape is obsolete
```